### PR TITLE
fix: corrigir validação de nome no cadastro de clientes

### DIFF
--- a/src/pages/customers.tsx
+++ b/src/pages/customers.tsx
@@ -75,12 +75,12 @@ export default function Customers() {
 
   const handleSubmit = async (values: any) => {
     try {
-      // Obter todos os valores do formulário (incluindo campos de outros passos)
-      const allValues = form.getFieldsValue()
-      const customerName = allValues.name || values.name
+      // Obter todos os valores do formulário (incluindo campos de outros passos/desmontados)
+      const allValues = form.getFieldsValue(true)
+      const customerName = (allValues.name || values.name || '').trim()
       
       // Validar nome do cliente
-      if (!customerName || !customerName.trim() || customerName.trim().length < 2) {
+      if (!customerName || customerName.length < 2) {
         message.error('Nome deve ter pelo menos 2 caracteres')
         return
       }
@@ -98,7 +98,7 @@ export default function Customers() {
 
       // Preparar dados do cliente - usar todos os valores do formulário
       const customerData: any = {
-        name: customerName.trim(),
+        name: customerName,
       }
 
       if (allValues.email?.trim()) customerData.email = allValues.email.trim()
@@ -447,28 +447,15 @@ export default function Customers() {
             label="Nome Completo"
             rules={[
               { required: true, message: 'Por favor, insira o nome do cliente' },
-              { 
+              {
                 validator: (_, value) => {
                   if (!value || value.trim().length < 2) {
                     return Promise.reject(new Error('Nome deve ter pelo menos 2 caracteres'))
-                  }
-                  if (!value.trim()) {
-                    return Promise.reject(new Error('Nome não pode ser apenas espaços'))
                   }
                   return Promise.resolve()
                 }
               }
             ]}
-            normalize={(value) => {
-              const trimmed = value?.trim() || ''
-              if (trimmed !== value) {
-                // Força o update do valor
-                setTimeout(() => {
-                  form.setFieldValue('name', trimmed)
-                }, 0)
-              }
-              return trimmed
-            }}
           >
             <Input 
               placeholder="Digite o nome completo" 


### PR DESCRIPTION
## Problema

O campo de nome no formulário multi-step de cadastro de clientes tinha um bug onde a função `normalize` utilizava `setTimeout + setFieldValue` para trimmar o valor. Isso causava um race condition: o timeout disparava **após** o usuário preencher o campo, resetando o nome para `''`.

Além disso, `form.getFieldsValue()` não retornava os valores de campos desmontados (step 0), causando falha silenciosa no submit.

## Correções

- Remove a função `normalize` com `setTimeout` do campo nome (causava reset assíncrono do valor)
- Usa `form.getFieldsValue(true)` para recuperar valores de todos os campos, incluindo desmontados
- Simplifica a validação do nome no `handleSubmit`

Closes #2