### PR TITLE
fix: corrigir redirect após login para dashboard

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -103,6 +103,7 @@ export default function Layout({ children }: LayoutProps) {
   const handleLogout = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    document.cookie = 'token=; path=/; max-age=0; samesite=strict'
     router.push('/login')
   }
 

--- a/src/components/Layout/LayoutNew.tsx
+++ b/src/components/Layout/LayoutNew.tsx
@@ -395,6 +395,7 @@ export default function LayoutNew({ children }: LayoutProps) {
   const handleLogout = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    document.cookie = 'token=; path=/; max-age=0; samesite=strict'
     router.push('/login')
   }
 

--- a/src/components/Layout/LayoutWithPermissions.tsx
+++ b/src/components/Layout/LayoutWithPermissions.tsx
@@ -45,6 +45,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const handleLogout = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    document.cookie = 'token=; path=/; max-age=0; samesite=strict'
     router.push('/login')
   }
 

--- a/src/components/Layout/PersistentLayout.tsx
+++ b/src/components/Layout/PersistentLayout.tsx
@@ -111,6 +111,7 @@ export default function PersistentLayout({ children }: LayoutProps) {
   const handleLogout = () => {
     localStorage.removeItem('token')
     localStorage.removeItem('user')
+    document.cookie = 'token=; path=/; max-age=0; samesite=strict'
     router.push('/login')
   }
 

--- a/src/hooks/useSecureAuth.tsx
+++ b/src/hooks/useSecureAuth.tsx
@@ -76,6 +76,7 @@ export const useSecureAuth = () => {
 
   const logout = () => {
     localStorage.removeItem('token')
+    document.cookie = 'token=; path=/; max-age=0; samesite=strict'
     setUser(null)
     setPermissions(null)
     setIsAuthenticated(false)

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -29,12 +29,16 @@ export default function Login() {
       if (response.ok) {
         const data = await response.json()
         
-        // Armazenar token JWT e dados do usuário temporariamente
+        // Armazenar token JWT e dados do usuário
         localStorage.setItem('token', data.access_token)
         localStorage.setItem('user', JSON.stringify(data.user))
-        
+
+        // Salvar token em cookie para que o middleware de rotas protegidas possa validar
+        const maxAge = 7 * 24 * 60 * 60 // 7 dias em segundos
+        document.cookie = `token=${data.access_token}; path=/; max-age=${maxAge}; samesite=strict`
+
         message.success('Login realizado com sucesso!')
-        
+
         // Redirecionar para dashboard
         router.push('/dashboard')
       } else {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -91,6 +91,7 @@ class ApiService {
     if (status === 401) {
       localStorage.removeItem('token')
       localStorage.removeItem('user')
+      document.cookie = 'token=; path=/; max-age=0; samesite=strict'
       window.location.href = '/login'
       throw new Error('Unauthorized')
     }


### PR DESCRIPTION
## Problema

Após login bem-sucedido, o redirect para `/dashboard` não funcionava. O usuário era enviado de volta para `/login`.

**Causa raiz:** O middleware (`middleware.ts`) valida autenticação lendo o token de **cookies**, mas a página de login salvava o token apenas no `localStorage`. Na requisição para `/dashboard`, o middleware não encontrava o cookie e redirecionava para login.

## Correções

- `login.tsx`: Salva o token em cookie (`token=...; path=/; max-age=7d`) além do localStorage
- Todos os handlers de logout (`Layout`, `LayoutNew`, `PersistentLayout`, `LayoutWithPermissions`, `useSecureAuth`): limpam o cookie ao sair
- `api.ts` (`handleAuthError`): limpa o cookie quando recebe 401

## Fluxo corrigido

```
Login → salva localStorage + cookie → router.push('/dashboard')
Middleware lê cookie → válido → acesso permitido ✓
Logout → remove localStorage + cookie → router.push('/login') ✓
```

Closes #15