### PR TITLE
feat: dark mode, loading skeletons e empty states padronizados

### DIFF
--- a/src/components/Layout/PersistentLayout.tsx
+++ b/src/components/Layout/PersistentLayout.tsx
@@ -1,29 +1,30 @@
 import React, { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import Image from 'next/image'
-import { Layout as AntLayout, Menu, Avatar, Dropdown, Button, Badge, Space, Typography, Popover, List, Empty, Divider, message } from 'antd'
+import { Layout as AntLayout, Menu, Avatar, Dropdown, Button, Badge, Space, Typography, Popover, List, Empty, Divider, message, Tooltip } from 'antd'
 import { usePersonalization } from '../../hooks/usePersonalization'
 import { useGlobalPersonalization } from '../../hooks/useGlobalPersonalization'
 import { usePermissions } from '../../hooks/usePermissions'
+import { useTheme } from '../../contexts/ThemeContext'
 import { apiService } from '../../services/api'
 import TrialBanner from '../TrialBanner'
 import PlanBadge from '../PlanBadge'
-import { 
-  DashboardOutlined, 
-  UserOutlined, 
-  TeamOutlined, 
-  CalendarOutlined, 
-  ToolOutlined, 
-  ShoppingOutlined, 
-  ShoppingCartOutlined, 
-  MedicineBoxOutlined, 
-  HeartOutlined, 
-  BarChartOutlined, 
-  DollarOutlined, 
-  SettingOutlined, 
-  LogoutOutlined, 
-  BellOutlined, 
-  MenuFoldOutlined, 
+import {
+  DashboardOutlined,
+  UserOutlined,
+  TeamOutlined,
+  CalendarOutlined,
+  ToolOutlined,
+  ShoppingOutlined,
+  ShoppingCartOutlined,
+  MedicineBoxOutlined,
+  HeartOutlined,
+  BarChartOutlined,
+  DollarOutlined,
+  SettingOutlined,
+  LogoutOutlined,
+  BellOutlined,
+  MenuFoldOutlined,
   MenuUnfoldOutlined,
   BgColorsOutlined,
   DatabaseOutlined,
@@ -34,7 +35,9 @@ import {
   CustomerServiceOutlined,
   ControlOutlined,
   InboxOutlined,
-  AppstoreOutlined
+  AppstoreOutlined,
+  SunOutlined,
+  MoonOutlined
 } from '@ant-design/icons'
 
 const { Header, Sider, Content } = AntLayout
@@ -52,8 +55,9 @@ export default function PersistentLayout({ children }: LayoutProps) {
   const [loadingNotifications, setLoadingNotifications] = useState(false)
   const router = useRouter()
   const { settings: personalizationSettings } = usePersonalization()
-  useGlobalPersonalization() // Aplicar configurações globais
+  useGlobalPersonalization()
   const { canAccessSidebarItem, user: userFromHook, loading: permissionsLoading } = usePermissions()
+  const { isDark, toggleTheme } = useTheme()
 
   // Carregar dados do usuário apenas uma vez
   useEffect(() => {
@@ -388,8 +392,12 @@ export default function PersistentLayout({ children }: LayoutProps) {
     return titles[pathname] || 'PetFlow'
   }
 
+  const headerBg = isDark ? '#1f2937' : (personalizationSettings.headerColor ?? '#fff')
+  const contentBg = isDark ? '#111827' : '#fff'
+  const layoutBg = isDark ? '#0d1117' : '#f9fafb'
+
   return (
-    <AntLayout style={{ minHeight: '100vh' }}>
+    <AntLayout style={{ minHeight: '100vh', background: layoutBg }}>
       <Sider 
         trigger={null} 
         collapsible 
@@ -486,8 +494,8 @@ export default function PersistentLayout({ children }: LayoutProps) {
       </Sider>
 
       <AntLayout style={{ marginLeft: collapsed ? 80 : 256 }}>
-        <Header style={{ 
-          background: personalizationSettings.headerColor ?? '#fff', 
+        <Header style={{
+          background: headerBg,
           padding: '0 24px', 
           boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
           position: 'fixed',
@@ -521,6 +529,17 @@ export default function PersistentLayout({ children }: LayoutProps) {
 
           <Space size="middle">
             <PlanBadge />
+
+            <Tooltip title={isDark ? 'Modo claro' : 'Modo escuro'}>
+              <Button
+                type="text"
+                icon={isDark
+                  ? <SunOutlined style={{ fontSize: 18, color: '#facc15' }} />
+                  : <MoonOutlined style={{ fontSize: 18, color: '#6b7280' }} />
+                }
+                onClick={toggleTheme}
+              />
+            </Tooltip>
             
             <Popover
               content={
@@ -685,10 +704,10 @@ export default function PersistentLayout({ children }: LayoutProps) {
           <TrialBanner />
         </div>
         
-        <Content style={{ 
-          margin: '24px 16px', 
-          padding: 24, 
-          background: '#fff', 
+        <Content style={{
+          margin: '24px 16px',
+          padding: 24,
+          background: contentBg,
           borderRadius: personalizationSettings.borderRadius ?? 8,
           marginTop: '88px',
           fontSize: personalizationSettings.fontSize ? `${personalizationSettings.fontSize}px` : '14px',

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import { Button, Empty } from 'antd'
+import { PlusOutlined } from '@ant-design/icons'
+
+interface EmptyStateProps {
+  icon?: React.ReactNode
+  title: string
+  description?: string
+  actionLabel?: string
+  onAction?: () => void
+  compact?: boolean
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({
+  icon,
+  title,
+  description,
+  actionLabel,
+  onAction,
+  compact = false,
+}) => {
+  return (
+    <div className={`flex flex-col items-center justify-center text-center ${compact ? 'py-8' : 'py-16'}`}>
+      {icon && (
+        <div className="text-gray-300 dark:text-gray-600 mb-4" style={{ fontSize: compact ? 40 : 56 }}>
+          {icon}
+        </div>
+      )}
+      {!icon && (
+        <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
+          description={null}
+          style={{ marginBottom: 8 }}
+        />
+      )}
+      <h3 className={`font-semibold text-gray-700 dark:text-gray-300 mt-2 ${compact ? 'text-base' : 'text-lg'}`}>
+        {title}
+      </h3>
+      {description && (
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400 max-w-xs">
+          {description}
+        </p>
+      )}
+      {actionLabel && onAction && (
+        <Button
+          type="primary"
+          icon={<PlusOutlined />}
+          onClick={onAction}
+          className="mt-4"
+        >
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/src/components/common/PageSkeleton.tsx
+++ b/src/components/common/PageSkeleton.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import { Skeleton, Card, Row, Col } from 'antd'
+
+interface PageSkeletonProps {
+  type?: 'table' | 'cards' | 'detail' | 'dashboard'
+  rows?: number
+}
+
+export const TableSkeleton: React.FC<{ rows?: number }> = ({ rows = 6 }) => (
+  <div>
+    <div className="flex gap-3 mb-4">
+      <Skeleton.Input active style={{ width: 240 }} />
+      <Skeleton.Input active style={{ width: 120 }} />
+      <Skeleton.Button active style={{ marginLeft: 'auto' }} />
+    </div>
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+      <div className="bg-gray-50 dark:bg-gray-800 px-4 py-3 flex gap-4 border-b border-gray-200 dark:border-gray-700">
+        {[30, 20, 15, 15, 20].map((w, i) => (
+          <Skeleton.Input key={i} active size="small" style={{ width: `${w}%` }} />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="px-4 py-3 flex gap-4 border-b border-gray-100 dark:border-gray-800 last:border-0">
+          {[30, 20, 15, 15, 20].map((w, j) => (
+            <Skeleton.Input key={j} active size="small" style={{ width: `${w}%` }} />
+          ))}
+        </div>
+      ))}
+    </div>
+  </div>
+)
+
+export const CardsSkeleton: React.FC<{ count?: number }> = ({ count = 4 }) => (
+  <Row gutter={[16, 16]}>
+    {Array.from({ length: count }).map((_, i) => (
+      <Col key={i} xs={24} sm={12} lg={6}>
+        <Card>
+          <Skeleton active paragraph={{ rows: 2 }} />
+        </Card>
+      </Col>
+    ))}
+  </Row>
+)
+
+export const DashboardSkeleton: React.FC = () => (
+  <div className="space-y-6">
+    <Row gutter={[16, 16]}>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Col key={i} xs={24} sm={12} xl={6}>
+          <Card>
+            <Skeleton active paragraph={{ rows: 1 }} />
+          </Card>
+        </Col>
+      ))}
+    </Row>
+    <Row gutter={[16, 16]}>
+      <Col xs={24} lg={16}>
+        <Card>
+          <Skeleton active paragraph={{ rows: 6 }} />
+        </Card>
+      </Col>
+      <Col xs={24} lg={8}>
+        <Card>
+          <Skeleton active paragraph={{ rows: 6 }} />
+        </Card>
+      </Col>
+    </Row>
+  </div>
+)
+
+export const DetailSkeleton: React.FC = () => (
+  <div className="space-y-4">
+    <Skeleton active paragraph={{ rows: 0 }} style={{ width: 300 }} />
+    <Card>
+      <Skeleton active paragraph={{ rows: 4 }} />
+    </Card>
+    <Card>
+      <Skeleton active paragraph={{ rows: 3 }} />
+    </Card>
+  </div>
+)
+
+const PageSkeleton: React.FC<PageSkeletonProps> = ({ type = 'table', rows = 6 }) => {
+  switch (type) {
+    case 'cards':
+      return <CardsSkeleton count={rows} />
+    case 'dashboard':
+      return <DashboardSkeleton />
+    case 'detail':
+      return <DetailSkeleton />
+    default:
+      return <TableSkeleton rows={rows} />
+  }
+}
+
+export default PageSkeleton

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useState, useEffect } from 'react'
+
+interface ThemeContextType {
+  isDark: boolean
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  isDark: false,
+  toggleTheme: () => {},
+})
+
+export const useTheme = () => useContext(ThemeContext)
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [isDark, setIsDark] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme')
+    if (stored) {
+      setIsDark(stored === 'dark')
+    } else {
+      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      setIsDark(prefersDark)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (isDark) {
+      document.documentElement.setAttribute('data-theme', 'dark')
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light')
+      document.documentElement.classList.remove('dark')
+    }
+    localStorage.setItem('theme', isDark ? 'dark' : 'light')
+  }, [isDark])
+
+  const toggleTheme = () => setIsDark(prev => !prev)
+
+  return (
+    <ThemeContext.Provider value={{ isDark, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,6 +1,8 @@
 import type { AppProps } from 'next/app'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
+import { ConfigProvider, theme as antTheme } from 'antd'
+import ptBR from 'antd/locale/pt_BR'
 import '../styles/globals.css'
 import '../styles/sidebar.css'
 import 'react-big-calendar/lib/css/react-big-calendar.css'
@@ -9,16 +11,16 @@ import PersistentLayout from '../components/Layout/PersistentLayout'
 import { PermissionProvider } from '../hooks/usePermissions'
 import { RouteGuard } from '../components/RouteGuard'
 import { ErrorBoundary } from '../components/ErrorBoundary'
+import { ThemeProvider, useTheme } from '../contexts/ThemeContext'
 
-export default function App({ Component, pageProps }: AppProps) {
+function AppContent({ Component, pageProps }: AppProps) {
   const router = useRouter()
-  
-  // Lista de páginas públicas que não devem usar o layout
+  const { isDark } = useTheme()
+
   const publicPages = ['/login', '/', '/complete-registration']
   const isPublicPage = publicPages.includes(router.pathname)
 
   useEffect(() => {
-    // Preload das páginas mais comuns
     const preloadPages = ['/dashboard', '/customers', '/pets', '/appointments']
     preloadPages.forEach(page => {
       const link = document.createElement('link')
@@ -28,26 +30,45 @@ export default function App({ Component, pageProps }: AppProps) {
     })
   }, [])
 
-  // Renderização condicional baseada na rota
-  if (isPublicPage) {
-    return (
-      <ErrorBoundary>
-        <Component {...pageProps} />
-      </ErrorBoundary>
-    )
-  }
-
-  // Para todas as outras páginas, usar layout persistente
   return (
-    <ErrorBoundary>
-      <PermissionProvider>
-        <PersistentLayout>
-          <RouteGuard>
-            <Component {...pageProps} />
-          </RouteGuard>
-        </PersistentLayout>
-      </PermissionProvider>
-    </ErrorBoundary>
+    <ConfigProvider
+      locale={ptBR}
+      theme={{
+        algorithm: isDark ? antTheme.darkAlgorithm : antTheme.defaultAlgorithm,
+        token: {
+          colorPrimary: '#047857',
+          colorSuccess: '#10b981',
+          colorWarning: '#f59e0b',
+          colorError: '#ef4444',
+          colorInfo: '#3b82f6',
+          borderRadius: 8,
+          fontFamily: "'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+        },
+      }}
+    >
+      {isPublicPage ? (
+        <ErrorBoundary>
+          <Component {...pageProps} />
+        </ErrorBoundary>
+      ) : (
+        <ErrorBoundary>
+          <PermissionProvider>
+            <PersistentLayout>
+              <RouteGuard>
+                <Component {...pageProps} />
+              </RouteGuard>
+            </PersistentLayout>
+          </PermissionProvider>
+        </ErrorBoundary>
+      )}
+    </ConfigProvider>
   )
 }
 
+export default function App(props: AppProps) {
+  return (
+    <ThemeProvider>
+      <AppContent {...props} />
+    </ThemeProvider>
+  )
+}

--- a/src/pages/appointments.tsx
+++ b/src/pages/appointments.tsx
@@ -4,6 +4,8 @@ import { Modal, Form, Input, message, Select, Button, Table, Tag, Avatar, Space,
 import type { ColumnsType } from 'antd/es/table'
 import { apiService, extractArrayFromResponse } from '../services/api'
 import { AppointmentForm } from '../components/appointments/AppointmentForm'
+import PageSkeleton from '../components/common/PageSkeleton'
+import EmptyState from '../components/common/EmptyState'
 import { AppointmentFilters } from '../components/appointments/AppointmentFilters'
 import { 
   PlusOutlined, 
@@ -334,14 +336,7 @@ export default function Appointments() {
   ]
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-green-600"></div>
-          <p className="mt-4 text-gray-600">Carregando...</p>
-        </div>
-      </div>
-    )
+    return <PageSkeleton type="table" rows={8} />
   }
 
   return (
@@ -486,36 +481,13 @@ export default function Appointments() {
             className="custom-table"
             locale={{
               emptyText: (
-                <div className="text-center py-12">
-                  <CalendarOutlined className="text-6xl text-gray-300 mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mt-4">Nenhum agendamento encontrado</h3>
-                  <p className="mt-2 text-sm text-gray-500 mb-6">
-                    {searchTerm || filterStatus || filterCustomer ? 'Tente ajustar seus filtros.' : 'Comece criando o primeiro agendamento.'}
-                  </p>
-                  {!searchTerm && !filterStatus && !filterCustomer && (
-                    <Button
-                      type="primary"
-                      icon={<PlusOutlined />}
-                      onClick={() => setShowModal(true)}
-                      size="large"
-                      className="bg-green-600 hover:bg-green-700 hover:border-green-700 border-green-600 px-6 py-3"
-                      style={{
-                        backgroundColor: '#16a34a',
-                        borderColor: '#16a34a'
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.backgroundColor = '#15803d'
-                        e.currentTarget.style.borderColor = '#15803d'
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.backgroundColor = '#16a34a'
-                        e.currentTarget.style.borderColor = '#16a34a'
-                      }}
-                    >
-                      Criar Primeiro Agendamento
-                    </Button>
-                  )}
-                </div>
+                <EmptyState
+                  icon={<CalendarOutlined />}
+                  title="Nenhum agendamento encontrado"
+                  description={searchTerm || filterStatus || filterCustomer ? 'Tente ajustar seus filtros.' : 'Comece criando o primeiro agendamento.'}
+                  actionLabel={!searchTerm && !filterStatus && !filterCustomer ? 'Criar Primeiro Agendamento' : undefined}
+                  onAction={!searchTerm && !filterStatus && !filterCustomer ? () => setShowModal(true) : undefined}
+                />
               )
             }}
           />

--- a/src/pages/customers.tsx
+++ b/src/pages/customers.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { Modal, Form, Input, message, DatePicker, Select, Button, Steps, InputNumber, Switch, Row, Col, Upload, Avatar, Table, Tag } from 'antd'
+import PageSkeleton from '../components/common/PageSkeleton'
+import EmptyState from '../components/common/EmptyState'
 import type { ColumnsType } from 'antd/es/table'
 import { apiService, extractArrayFromResponse } from '../services/api'
 import { PlusOutlined, UserOutlined, MailOutlined, PhoneOutlined, IdcardOutlined, EnvironmentOutlined, SearchOutlined, EditOutlined, CameraOutlined, DollarOutlined, EyeOutlined } from '@ant-design/icons'
@@ -426,16 +428,7 @@ export default function Customers() {
     },
   ]
 
-  if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-green-600"></div>
-          <p className="mt-4 text-gray-600">Carregando...</p>
-        </div>
-      </div>
-    )
-  }
+  if (loading) return <PageSkeleton type="table" rows={8} />
 
   const steps = [
     {
@@ -895,24 +888,13 @@ export default function Customers() {
             className="custom-table"
             locale={{
               emptyText: (
-                <div className="text-center py-12">
-                  <UserOutlined className="text-6xl text-gray-300 mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mt-4">Nenhum cliente encontrado</h3>
-                  <p className="mt-2 text-sm text-gray-500 mb-6">
-                    {searchTerm ? 'Tente ajustar seus filtros.' : 'Comece adicionando seu primeiro cliente.'}
-                  </p>
-                  {!searchTerm && (
-                    <Button
-                      type="primary"
-                      icon={<PlusOutlined />}
-                      onClick={() => setShowModal(true)}
-                      size="large"
-                      className="bg-green-600 hover:bg-green-700 border-green-600"
-                    >
-                      Adicionar Primeiro Cliente
-                    </Button>
-                  )}
-                </div>
+                <EmptyState
+                  icon={<UserOutlined />}
+                  title="Nenhum cliente encontrado"
+                  description={searchTerm ? 'Tente ajustar seus filtros.' : 'Comece adicionando seu primeiro cliente.'}
+                  actionLabel={!searchTerm ? 'Adicionar Primeiro Cliente' : undefined}
+                  onAction={!searchTerm ? () => setShowModal(true) : undefined}
+                />
               )
             }}
           />

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
-import { Row, Col, Card, Statistic, List, Avatar, Space, Typography, Spin, message, Button } from 'antd'
-import { 
-  UserOutlined, 
-  HeartOutlined, 
-  CalendarOutlined, 
+import { Row, Col, Card, Statistic, List, Avatar, Space, Typography, message, Button } from 'antd'
+import {
+  UserOutlined,
+  HeartOutlined,
+  CalendarOutlined,
   DollarOutlined
 } from '@ant-design/icons'
 import { apiService } from '../services/api'
+import { DashboardSkeleton } from '../components/common/PageSkeleton'
+import EmptyState from '../components/common/EmptyState'
 
 interface User {
   id: string
@@ -62,6 +64,8 @@ export default function Dashboard() {
   }
 
   const { Title, Text } = Typography
+
+  if (loading) return <DashboardSkeleton />
 
   return (
     <div>
@@ -135,7 +139,7 @@ export default function Dashboard() {
           >
             <List
               dataSource={stats?.recentActivity || []}
-              locale={{ emptyText: 'Nenhuma atividade recente' }}
+              locale={{ emptyText: <EmptyState title="Nenhuma atividade recente" compact /> }}
               renderItem={(activity, index) => (
                 <List.Item className="hover:bg-gray-50 transition-colors">
                   <List.Item.Meta

--- a/src/pages/pets.tsx
+++ b/src/pages/pets.tsx
@@ -3,6 +3,8 @@ import { useRouter } from 'next/router'
 import { Modal, Form, Input, message, Select, Button, Table, Tag, Avatar, Space, Popconfirm, InputNumber, Upload, Card, Divider, Row, Col } from 'antd'
 import type { ColumnsType } from 'antd/es/table'
 import { apiService, extractArrayFromResponse } from '../services/api'
+import PageSkeleton from '../components/common/PageSkeleton'
+import EmptyState from '../components/common/EmptyState'
 import { 
   PlusOutlined, 
   HeartOutlined, 
@@ -259,14 +261,7 @@ export default function Pets() {
 
 
   if (loading) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-green-600"></div>
-          <p className="mt-4 text-gray-600">Carregando...</p>
-        </div>
-      </div>
-    )
+    return <PageSkeleton type="table" rows={8} />
   }
 
   return (
@@ -360,24 +355,13 @@ export default function Pets() {
             className="custom-table"
             locale={{
               emptyText: (
-                <div className="text-center py-12">
-                  <HeartOutlined className="text-6xl text-gray-300 mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mt-4">Nenhum pet encontrado</h3>
-                  <p className="mt-2 text-sm text-gray-500 mb-6">
-                    {searchTerm || filterSpecies || filterCustomer ? 'Tente ajustar seus filtros.' : 'Comece adicionando o primeiro pet.'}
-                  </p>
-                  {!searchTerm && !filterSpecies && !filterCustomer && (
-                    <Button
-                      type="primary"
-                      icon={<PlusOutlined />}
-                      onClick={() => setShowModal(true)}
-                      size="large"
-                      className="bg-green-600 hover:bg-green-700 border-green-600"
-                    >
-                      Adicionar Primeiro Pet
-                    </Button>
-                  )}
-                </div>
+                <EmptyState
+                  icon={<HeartOutlined />}
+                  title="Nenhum pet encontrado"
+                  description={searchTerm || filterSpecies || filterCustomer ? 'Tente ajustar seus filtros.' : 'Comece adicionando o primeiro pet.'}
+                  actionLabel={!searchTerm && !filterSpecies && !filterCustomer ? 'Adicionar Primeiro Pet' : undefined}
+                  onAction={!searchTerm && !filterSpecies && !filterCustomer ? () => setShowModal(true) : undefined}
+                />
               )
             }}
           />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -13,6 +13,33 @@
     --border-radius: 8px;
     --font-size: 14px;
     --font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+    /* Light mode tokens */
+    --bg-base: #f9fafb;
+    --bg-surface: #ffffff;
+    --bg-elevated: #f3f4f6;
+    --text-primary: #111827;
+    --text-secondary: #6b7280;
+    --border-color: #e5e7eb;
+  }
+
+  [data-theme='dark'] {
+    --bg-base: #0d1117;
+    --bg-surface: #111827;
+    --bg-elevated: #1f2937;
+    --text-primary: #f9fafb;
+    --text-secondary: #9ca3af;
+    --border-color: #374151;
+    --header-color: #1f2937;
+  }
+
+  [data-theme='dark'] body {
+    color: var(--text-primary);
+    background-color: var(--bg-base);
+  }
+
+  [data-theme='dark'] .loading-overlay {
+    background: rgba(17, 24, 39, 0.85);
   }
 
   html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: [
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',


### PR DESCRIPTION
## Issues resolvidas
Closes #40, #25, #26

---

## 🌙 Dark Mode (Issue #40)

### O que foi implementado
- **`ThemeContext`** (`src/contexts/ThemeContext.tsx`) — gerencia o estado claro/escuro com:
  - Persistência automática em `localStorage`
  - Detecção de `prefers-color-scheme` do sistema na primeira visita
  - Aplica `data-theme="dark"` e classe `dark` no `<html>`

- **`ConfigProvider`** no `_app.tsx` — o Ant Design **não tinha** ConfigProvider antes (tema não era aplicado). Agora usa:
  - `theme.darkAlgorithm` ou `theme.defaultAlgorithm` baseado no ThemeContext
  - Token de cores correto (primary, success, warning, error)
  - Locale `pt-BR` para todos os componentes Ant Design

- **Botão de toggle** no header do layout — ícone ☀️/🌙 com tooltip

- **CSS variables dark mode** em `globals.css` — `[data-theme='dark']` define:
  `--bg-base`, `--bg-surface`, `--bg-elevated`, `--text-primary`, `--text-secondary`, `--border-color`

- **`tailwind.config.js`** — `darkMode: 'class'` habilitado para suporte a `dark:` classes

---

## ⏳ Loading Skeletons (Issue #25)

### Novo componente `PageSkeleton` (`src/components/common/PageSkeleton.tsx`)

Variantes disponíveis:
| Tipo | Uso |
|------|-----|
| `table` | Páginas com tabelas (default) |
| `cards` | Páginas com cards em grid |
| `dashboard` | Dashboard com stats + gráficos |
| `detail` | Páginas de detalhe/formulário |

### Páginas atualizadas
- **Dashboard** — `DashboardSkeleton` com 4 stat cards + 2 cards de conteúdo
- **Customers** — `TableSkeleton` com 8 linhas substituindo spinner fullscreen
- **Pets** — idem
- **Appointments** — idem

O spinner fullscreen `animate-spin rounded-full h-32 w-32` que ocupava a tela inteira e quebrava o layout foi removido de todas as páginas.

---

## 📭 Empty States (Issue #26)

### Novo componente `EmptyState` (`src/components/common/EmptyState.tsx`)

```tsx
<EmptyState
  icon={<UserOutlined />}
  title="Nenhum cliente encontrado"
  description="Tente ajustar seus filtros."
  actionLabel="Adicionar Cliente"
  onAction={() => setShowModal(true)}
  compact // opcional, reduz o padding
/>
```

### Páginas atualizadas
- **Dashboard** — atividade recente vazia
- **Customers** — tabela vazia (com/sem filtros)
- **Pets** — tabela vazia (com/sem filtros)
- **Appointments** — tabela vazia (com/sem filtros)

Remove ~60 linhas de código duplicado de empty states manuais.

---

## Como testar
1. Abrir o sistema logado
2. Clicar no ícone 🌙 no header → tema escuro ativa
3. Recarregar a página → preferência persiste
4. Entrar em Clientes/Pets/Agendamentos → skeleton durante carregamento
5. Filtrar sem resultados → empty state com ícone e botão de ação

🤖 Generated with [Claude Code](https://claude.com/claude-code)