### PR TITLE
fix: corrigir rotas 404 e TypeError no hotel (#43, #44, #45)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,20 @@ const nextConfig = {
     // Permite que o build continue mesmo com erros de tipo (se necessário)
     ignoreBuildErrors: false,
   },
+  async redirects() {
+    return [
+      {
+        source: '/financial',
+        destination: '/financial-reports',
+        permanent: true,
+      },
+      {
+        source: '/register',
+        destination: '/complete-registration',
+        permanent: false,
+      },
+    ]
+  },
   async rewrites() {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'
     return [

--- a/src/pages/hotel.tsx
+++ b/src/pages/hotel.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { Card, Table, Button, Modal, Form, Input, Select, DatePicker, message, Tag, Space, Tabs, Statistic, Row, Col, InputNumber, Descriptions } from 'antd'
 import { PlusOutlined, HomeOutlined, LoginOutlined, LogoutOutlined, CalendarOutlined } from '@ant-design/icons'
-import { apiService } from '../services/api'
+import { apiService, extractArrayFromResponse } from '../services/api'
 import dayjs from 'dayjs'
 
 const { TabPane } = Tabs
@@ -50,16 +50,16 @@ export default function Hotel() {
         apiService.getHotelStats()
       ])
 
-      if (roomsResult.status === 'fulfilled') setRooms(roomsResult.value as any)
+      if (roomsResult.status === 'fulfilled') setRooms(extractArrayFromResponse(roomsResult.value))
       else message.warning('Erro ao carregar quartos')
 
-      if (bookingsResult.status === 'fulfilled') setBookings(bookingsResult.value as any)
+      if (bookingsResult.status === 'fulfilled') setBookings(extractArrayFromResponse(bookingsResult.value))
       else message.warning('Erro ao carregar reservas')
 
-      if (customersResult.status === 'fulfilled') setCustomers(customersResult.value as any)
+      if (customersResult.status === 'fulfilled') setCustomers(extractArrayFromResponse(customersResult.value, ['data', 'customers', 'items']))
       else message.warning('Erro ao carregar clientes')
 
-      if (petsResult.status === 'fulfilled') setPets(petsResult.value as any)
+      if (petsResult.status === 'fulfilled') setPets(extractArrayFromResponse(petsResult.value, ['data', 'pets', 'items']))
       else message.warning('Erro ao carregar pets')
 
       if (statsResult.status === 'fulfilled') setStats(statsResult.value as any)
@@ -159,8 +159,8 @@ export default function Hotel() {
         apiService.getHotelDailyReports(booking.id),
         apiService.getHotelServiceUsage(booking.id)
       ])
-      setDailyReports(reports as any)
-      setServiceUsage(services as any)
+      setDailyReports(extractArrayFromResponse(reports))
+      setServiceUsage(extractArrayFromResponse(services))
       setShowDailyReportModal(true)
     } catch (error) {
       message.error('Erro ao carregar detalhes')
@@ -179,7 +179,7 @@ export default function Hotel() {
       message.success('Relatório diário adicionado!')
       reportForm.resetFields()
       const reports = await apiService.getHotelDailyReports(selectedBooking.id)
-      setDailyReports(reports as any)
+      setDailyReports(extractArrayFromResponse(reports))
     } catch (error) {
       message.error('Erro ao adicionar relatório')
     }


### PR DESCRIPTION
## Resumo

- **#43** — Redirect `/financial` → `/financial-reports` via `next.config.js`
- **#44** — Uso de `extractArrayFromResponse` no `hotel.tsx` para lidar com respostas paginadas da API que causavam `TypeError: M.map is not a function`
- **#45** — Redirect `/register` → `/complete-registration` via `next.config.js`; o redirect server-side impede que o layout protegido carregue, resolvendo também o 401 em `/settings/personalization`

Closes #43, #44, #45

## Plano de testes

- [ ] Acessar `/financial` e confirmar redirect para `/financial-reports`
- [ ] Acessar `/register` e confirmar redirect para `/complete-registration` sem erros 401 no console
- [ ] Acessar `/hotel` autenticado e confirmar que a página carrega sem `TypeError`
- [ ] Verificar que os selects de Cliente e Pet no modal de nova reserva do hotel são populados corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)